### PR TITLE
Update to latest bytestring

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,7 @@
+packages: .
+
+source-repository-package
+    type: git
+    location: https://github.com/haskell/bytestring
+    tag: bb6202c
+

--- a/eclair-haskell.cabal
+++ b/eclair-haskell.cabal
@@ -50,7 +50,7 @@ library
   build-depends:
       array <=1.0
     , base >=4.7 && <5
-    , bytestring ==0.11.*
+    , bytestring ==0.12.*
     , containers ==0.*
     , mtl ==2.*
     , profunctors ==5.*
@@ -84,7 +84,7 @@ test-suite eclair-haskell-test
   build-depends:
       array <=1.0
     , base >=4.7 && <5
-    , bytestring ==0.11.*
+    , bytestring ==0.12.*
     , containers ==0.*
     , eclair-haskell
     , hspec >=2.6.1 && <3.0.0

--- a/lib/Language/Eclair/Internal.hs
+++ b/lib/Language/Eclair/Internal.hs
@@ -23,7 +23,6 @@ import Foreign.Ptr
 import Foreign.Storable
 import qualified Language.Eclair.Internal.Bindings as Bindings
 import Prelude hiding (init)
-import qualified Data.Text.Foreign as T
 
 init :: IO (ForeignPtr Bindings.Program)
 init = mask_ $ do
@@ -67,5 +66,6 @@ decodeString prog index = do
     else do
       len <- peek (castPtr symbolPtr :: Ptr Word32)
       let utf8Ptr = symbolPtr `plusPtr` 4
-      stringPtr <- peek (castPtr utf8Ptr :: Ptr (Ptr Word8))
-      T.fromPtr stringPtr (fromIntegral len)
+      stringPtr <- peek (castPtr utf8Ptr :: Ptr (Ptr CChar))
+      bs <- BSU.unsafePackCStringLen (stringPtr, fromIntegral len)
+      pure $ TE.decodeUtf8 bs

--- a/package.yaml
+++ b/package.yaml
@@ -15,7 +15,7 @@ extra-source-files:
 dependencies:
   - base >= 4.7 && < 5
   - text == 2.*
-  - bytestring == 0.11.*
+  - bytestring == 0.12.*
   - vector >= 0.12.0 && < 1
   - array <= 1.0
   - containers == 0.*


### PR DESCRIPTION
Fixes a bug in C code executed by the bytestring library, used during decoding of Eclair strings.